### PR TITLE
2 fixes: name banner export, locked file fix

### DIFF
--- a/src/LegendaryCardMaker/LegendaryHeroMaker/HeroMaker.java
+++ b/src/LegendaryCardMaker/LegendaryHeroMaker/HeroMaker.java
@@ -450,6 +450,7 @@ public class HeroMaker extends CardMaker {
 	
 	public BufferedImage generateCard()
 	{
+		this.nameHighlight = nameHighlightTemplate;
 		int type = BufferedImage.TYPE_INT_ARGB;
 		if (exportToPNG)
 		{

--- a/src/LegendaryCardMaker/exporters/ExportHomeprintProgressBarDialog.java
+++ b/src/LegendaryCardMaker/exporters/ExportHomeprintProgressBarDialog.java
@@ -384,7 +384,10 @@ public class ExportHomeprintProgressBarDialog extends JPanel
         
       //new Write and clean up
         imageWriter.write(null, new IIOImage(image, null, imageMetaData), jpegParams);
+        ios.flush();
         ios.close();
+        fos.flush();
+        fos.close();
         imageWriter.dispose();
 	}
 }


### PR DESCRIPTION
Apply name highlight template value whenever a card is generated (fix
for Issue #5)

Close locked file streams during export to JPEG for Homeprint (fix for
Issue #6)